### PR TITLE
Fix mcpd cask installation failure on Linux by restricting xattr to macOS

### DIFF
--- a/Casks/mcpd.rb
+++ b/Casks/mcpd.rb
@@ -38,7 +38,7 @@ cask "mcpd" do
     ]
 
   postflight do
-    if system_command("/usr/bin/xattr", args: ["-h"]).exit_status == 0
+    if OS.mac? && system_command("/usr/bin/xattr", args: ["-h"]).exit_status == 0
       system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/mcpd"]
     end
   end


### PR DESCRIPTION
This PR fixes a cask installation failure on Linux by restricting the Apple quarantine attribute removal to macOS only. The issue occurred because Linux's `xattr` implementation doesn't support the `-r` flag or the `com.apple.quarantine` attribute used by Apple's Gatekeeper.

- Added an `OS.mac?` check to conditionally execute quarantine removal only on macOS
- Prevents installation failures on Linux while maintaining macOS functionality

PS: This fix was suggested by github copilot